### PR TITLE
Pra64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+cod: cod.o
+	ld -m elf_i386 -o cod cod.o
+
+cod.o: cod.asm
+	nasm -f elf cod.asm
+
 teste: teste.o
 	ld -m elf_i386 -o teste teste.o
 

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ teste: teste.o
 
 teste.o: teste.asm
 	nasm -f elf teste.asm
+
+loc: loc.c
+	gcc -g -o loc loc.c

--- a/cod.asm
+++ b/cod.asm
@@ -21,11 +21,11 @@ global      _start
 _start:
 
 
-    mov     ebp, esp
-    cmp     dword [ebp + 8], 1
+    ;mov     ebp, esp
+    cmp     dword [esp], 1
     je      NoArgs 
     
-    cmp     dword [ebp + 8], MAXARGS        ; check total args entered
+    cmp     dword [esp], MAXARGS        ; check total args entered
     ja      TooManyArgs                     ; if total is greater than MAXARGS, show error and quit
 
     mov     ebx, 3

--- a/cod.asm
+++ b/cod.asm
@@ -22,10 +22,10 @@ _start:
 
 
     mov     ebp, esp
-    cmp     dword [ebp + 4], 1
+    cmp     dword [ebp + 8], 1
     je      NoArgs 
     
-    cmp     dword [ebp + 4], MAXARGS        ; check total args entered
+    cmp     dword [ebp + 8], MAXARGS        ; check total args entered
     ja      TooManyArgs                     ; if total is greater than MAXARGS, show error and quit
 
     mov     ebx, 3
@@ -33,7 +33,7 @@ _start:
      
 
 DoNextArg: 
-    mov     edi, dword [ebp + 4 * ebx]
+    mov     edi, dword [ebp + 8 * ebx]
     test    edi, edi
     jz      Exit
     
@@ -48,16 +48,16 @@ DoNextArg:
 
 
 
-    mov     edx, dword [ebp + 4 * ebx]
+    mov     edx, dword [ebp + 8 * ebx]
 
     
     inc     ebx
     
-    mov     edi, dword [ebp + 4 * ebx]
+    mov     edi, dword [ebp + 8 * ebx]
     test    edi, edi
     jz      Exit
 
-    mov     ecx, dword [ebp + 4 * ebx]
+    mov     ecx, dword [ebp + 8 * ebx]
     
     ;create the file
     mov  eax, 8

--- a/loc.c
+++ b/loc.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    register char* esp asm("esp");
+    register char* ebp asm("ebp");
+
+    printf("esp aponta para: %p\n", esp);
+    printf("ebp aponta para: %p\n", ebp);
+    printf("Endereco argc: %p\n", &argc);
+    printf("Endereco argv: %p\n", &argv);
+    printf("Endereco argv[0]: %p\n", argv);
+}
+


### PR DESCRIPTION
O problema ao que parece é que a localização do argc e argv no programa tava errada. 

Eu fiz um programa em C pra achar argc e argv. Parece que argc fica exatamete em [esp] e argv em [esp - 0xC]. Mudando o comecinho do programa, parece que agora ele confere certo o número de argumentos. Falta corrigir o resto dos offsets. Cuidado que a cada chamada de função o esp e ebp mudam.